### PR TITLE
Update Cantaloupe to 4.1.7-2 (test)

### DIFF
--- a/iiif/test-iiif-values.yaml
+++ b/iiif/test-iiif-values.yaml
@@ -63,7 +63,7 @@ cantaloupe:
     enabled: false
   image:
     repository: "uclalibrary/cantaloupe-ucla"
-    tag: "4.1.7-1"
+    tag: "4.1.7-2"
   imagePullSecrets:
     - name: services-dockerhub-creds
   cantaloupe:

--- a/iiif/test-iiif-values.yaml
+++ b/iiif/test-iiif-values.yaml
@@ -63,7 +63,7 @@ cantaloupe:
     enabled: false
   image:
     repository: "uclalibrary/cantaloupe-ucla"
-    tag: "4.1.7-2"
+    tag: "4.1.7-3"
   imagePullSecrets:
     - name: services-dockerhub-creds
   cantaloupe:


### PR DESCRIPTION
Bump the Cantaloupe version on the test server to 4.1.7-2.