### PR TITLE
Use same FESTER_URL env var for access and ingest

### DIFF
--- a/iiif/prod-ingest-iiif-values.yaml
+++ b/iiif/prod-ingest-iiif-values.yaml
@@ -39,7 +39,7 @@ fester:
     - name: services-dockerhub-creds
   fester:
     env:
-      FESTER_URL: "https://ingest.iiif.library.ucla.edu"
+      FESTER_URL: "https://iiif.library.ucla.edu"
       IIIF_BASE_URL: "https://iiif.library.ucla.edu/iiif/2"
       FESTER_S3_REGION: "us-west-2"
       FESTERIZE_VERSION: "0.3.1"


### PR DESCRIPTION
This env var is used to configure only two things:

 * The prefix of all IIIF Presentation API resource URLs expressed in a manifest; and
 * The prefix of the IIIF Manifest URL that gets written to an output CSV.

Our access/read instance (iiif.library.ucla.edu) is responsible for configuring the former, while our ingest/write instance (ingest.iiif.library.ucla.edu) is responsible for the latter. In both cases, however, the value should be the base URL of the access instance.