### PR TITLE
Deploy Fester 0.19.0 to the production environment

### DIFF
--- a/iiif/prod-iiif-values.yaml
+++ b/iiif/prod-iiif-values.yaml
@@ -36,7 +36,7 @@ fester:
     enabled: false
   image:
     repository: "uclalibrary/fester"
-    tag: "0.18.0"
+    tag: "0.19.0"
   imagePullSecrets:
     - name: services-dockerhub-creds
   fester:

--- a/iiif/prod-ingest-iiif-values.yaml
+++ b/iiif/prod-ingest-iiif-values.yaml
@@ -34,7 +34,7 @@ fester:
     enabled: false
   image:
     repository: "uclalibrary/fester"
-    tag: "0.18.0"
+    tag: "0.19.0"
   imagePullSecrets:
     - name: services-dockerhub-creds
   fester:


### PR DESCRIPTION
Ideally we'll deploy this during our Tuesday morning maintenance window on 7/6.